### PR TITLE
JUnit format file attribute output

### DIFF
--- a/features/docs/formatters/junit_formatter.feature
+++ b/features/docs/formatters/junit_formatter.feature
@@ -83,7 +83,7 @@ Feature: JUnit output formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="1" errors="0" skipped="0" tests="2" time="0.05" name="One passing scenario, one failing scenario">
-      <testcase classname="One passing scenario, one failing scenario" name="Passing" time="0.05">
+      <testcase classname="One passing scenario, one failing scenario" name="Passing" time="0.05" file="features/one_passing_one_failing.feature">
         <system-out>
           <![CDATA[]]>
         </system-out>
@@ -91,7 +91,7 @@ Feature: JUnit output formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="One passing scenario, one failing scenario" name="Failing" time="0.05">
+      <testcase classname="One passing scenario, one failing scenario" name="Failing" time="0.05" file="features/one_passing_one_failing.feature">
         <failure message="failed Failing" type="failed">
           <![CDATA[Scenario: Failing
 
@@ -124,7 +124,7 @@ Feature: JUnit output formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="1" errors="0" skipped="0" tests="2" time="0.05" name="Subdirectory - One passing scenario, one failing scenario">
-      <testcase classname="Subdirectory - One passing scenario, one failing scenario" name="Passing" time="0.05">
+      <testcase classname="Subdirectory - One passing scenario, one failing scenario" name="Passing" time="0.05" file="features/some_subdirectory/one_passing_one_failing.feature">
         <system-out>
           <![CDATA[]]>
         </system-out>
@@ -132,7 +132,7 @@ Feature: JUnit output formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Subdirectory - One passing scenario, one failing scenario" name="Failing" time="0.05">
+      <testcase classname="Subdirectory - One passing scenario, one failing scenario" name="Failing" time="0.05" file="features/some_subdirectory/one_passing_one_failing.feature">
         <failure message="failed Failing" type="failed">
           <![CDATA[Scenario: Failing
 
@@ -165,7 +165,7 @@ Feature: JUnit output formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="0" errors="0" skipped="2" tests="2" time="0.05" name="Pending step">
-      <testcase classname="Pending step" name="Pending" time="0.05">
+      <testcase classname="Pending step" name="Pending" time="0.05" file="features/pending.feature">
         <skipped/>
         <system-out>
           <![CDATA[]]>
@@ -174,7 +174,7 @@ Feature: JUnit output formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Pending step" name="Undefined" time="0.05">
+      <testcase classname="Pending step" name="Undefined" time="0.05" file="features/pending.feature">
         <skipped/>
         <system-out>
           <![CDATA[]]>
@@ -197,7 +197,7 @@ Feature: JUnit output formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="2" errors="0" skipped="0" tests="2" time="0.05" name="Pending step">
-      <testcase classname="Pending step" name="Pending" time="0.05">
+      <testcase classname="Pending step" name="Pending" time="0.05" file="features/pending.feature">
         <failure message="pending Pending" type="pending">
           <![CDATA[Scenario: Pending
 
@@ -216,7 +216,7 @@ Feature: JUnit output formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Pending step" name="Undefined" time="0.05">
+      <testcase classname="Pending step" name="Undefined" time="0.05" file="features/pending.feature">
         <failure message="undefined Undefined" type="undefined">
           <![CDATA[Scenario: Undefined
 
@@ -268,7 +268,7 @@ You *must* specify --out DIR for the junit formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="3" errors="0" skipped="0" tests="4" time="0.05" name="Scenario outlines">
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | passes |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | passes |)" time="0.05" file="features/scenario_outline.feature">
         <system-out>
           <![CDATA[]]>
         </system-out>
@@ -276,7 +276,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | fails |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | fails |)" time="0.05" file="features/scenario_outline.feature">
         <failure message="failed Using scenario outlines (outline example : | fails |)" type="failed">
           <![CDATA[Scenario Outline: Using scenario outlines
 
@@ -295,7 +295,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is pending |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is pending |)" time="0.05" file="features/scenario_outline.feature">
         <failure message="pending Using scenario outlines (outline example : | is pending |)" type="pending">
           <![CDATA[Scenario Outline: Using scenario outlines
 
@@ -314,7 +314,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is undefined |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is undefined |)" time="0.05" file="features/scenario_outline.feature">
         <failure message="undefined Using scenario outlines (outline example : | is undefined |)" type="undefined">
           <![CDATA[Scenario Outline: Using scenario outlines
 
@@ -346,7 +346,7 @@ You *must* specify --out DIR for the junit formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="3" errors="0" skipped="0" tests="4" time="0.05" name="Scenario outlines">
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | passes |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | passes |)" time="0.05" file="features/scenario_outline.feature">
         <system-out>
           <![CDATA[]]>
         </system-out>
@@ -354,7 +354,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | fails |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | fails |)" time="0.05" file="features/scenario_outline.feature">
         <failure message="failed Using scenario outlines (outline example : | fails |)" type="failed">
           <![CDATA[Scenario Outline: Using scenario outlines
 
@@ -373,7 +373,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is pending |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is pending |)" time="0.05" file="features/scenario_outline.feature">
         <failure message="pending Using scenario outlines (outline example : | is pending |)" type="pending">
           <![CDATA[Scenario Outline: Using scenario outlines
 
@@ -392,7 +392,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is undefined |)" time="0.05">
+      <testcase classname="Scenario outlines" name="Using scenario outlines (outline example : | is undefined |)" time="0.05" file="features/scenario_outline.feature">
         <failure message="undefined Using scenario outlines (outline example : | is undefined |)" type="undefined">
           <![CDATA[Scenario Outline: Using scenario outlines
 
@@ -424,7 +424,7 @@ You *must* specify --out DIR for the junit formatter
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <testsuite failures="1" errors="0" skipped="0" tests="2" time="0.05" name="One passing scenario, one failing scenario">
-      <testcase classname="One passing scenario, one failing scenario" name="Passing" time="0.05">
+      <testcase classname="One passing scenario, one failing scenario" name="Passing" time="0.05" file="features/one_passing_one_failing.feature">
         <system-out>
           <![CDATA[]]>
         </system-out>
@@ -432,7 +432,7 @@ You *must* specify --out DIR for the junit formatter
           <![CDATA[]]>
         </system-err>
       </testcase>
-      <testcase classname="One passing scenario, one failing scenario" name="Failing" time="0.05">
+      <testcase classname="One passing scenario, one failing scenario" name="Failing" time="0.05" file="features/one_passing_one_failing.feature">
         <failure message="failed Failing" type="failed">
           <![CDATA[Scenario: Failing
 

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -132,9 +132,10 @@ module Cucumber
         duration = ResultBuilder.new(result).test_case_duration
         @current_feature_data[:time] += duration
         classname = @current_feature_data[:feature].name
+        filename = @current_feature_data[:uri]
         name = scenario_designation
 
-        @current_feature_data[:builder].testcase(classname: classname, name: name, time: format('%<duration>.6f', duration: duration)) do
+        @current_feature_data[:builder].testcase(classname: classname, name: name, time: format('%<duration>.6f', duration: duration), file: filename) do
           if !result.passed? && result.ok?(@config.strict)
             @current_feature_data[:builder].skipped
             @current_feature_data[:skipped] += 1

--- a/spec/cucumber/formatter/junit_spec.rb
+++ b/spec/cucumber/formatter/junit_spec.rb
@@ -123,6 +123,10 @@ module Cucumber
             it 'writes the filename with absolute path' do
               expect(@formatter.written_files.keys.first).to eq File.absolute_path('TEST-features-some-path-spec.xml')
             end
+
+            it 'includes the filename in the document' do
+              expect(@doc.xpath('//testcase/@file').to_s).to match(%r{features/some/path/spec.feature})
+            end
           end
 
           describe 'with a scenario outline table' do


### PR DESCRIPTION
A recreation of https://github.com/cucumber/cucumber-ruby/pull/1457. Keeping it here since cucumber core doesn't seem like they are going to merge it soon.

There is some information related here: https://discuss.circleci.com/t/split-by-timings-doesnt-work-for-cucumber-ruby/37022/3

original fork with this code is here: https://github.com/mkly/cucumber-ruby
